### PR TITLE
Don't try to preserve Anydesk archive content file owners

### DIFF
--- a/com.anydesk.Anydesk.json
+++ b/com.anydesk.Anydesk.json
@@ -174,7 +174,7 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "tar --strip-components=1 -xf anydesk.tar.gz",
+                        "tar --strip-components=1 -xf anydesk.tar.gz --no-same-owner",
                         "rm -f anydesk.tar.gz",
                         "chmod 755 anydesk"
                     ]


### PR DESCRIPTION
When extracting as root (i.e. when flatpak was run with root privileges),
tar defaults to --same-owner which leads to lots of ownership change
errors like the following:

    tar: anydesk: Cannot change ownership to uid 109, gid 114: Operation
      not permitted

This happens because files inside the archive have 109 and 114 as their
owner and group, respectively.

This commit adds --no-same-owner tar option to get rid of these errors.