### PR TITLE
Use "dest" to set script destination directory

### DIFF
--- a/com.anydesk.Anydesk.json
+++ b/com.anydesk.Anydesk.json
@@ -39,7 +39,8 @@
                 },
                 {
                     "type": "script",
-                    "dest-filename": "contrib/minizip/autogen.sh",
+                    "dest": "contrib/minizip/",
+                    "dest-filename": "autogen.sh",
                     "commands": [
                         "autoreconf -ifv"
                     ]


### PR DESCRIPTION
New flatpak-builder doesn't allow slashes in "dest-filename" values.

Fixes #59