### PR TITLE
Revert back polkit to v120

### DIFF
--- a/com.anydesk.Anydesk.json
+++ b/com.anydesk.Anydesk.json
@@ -105,8 +105,8 @@
                         "url-template": "https://www.freedesktop.org/software/polkit/releases/polkit-$version.tar.gz"
                     },
                     "type": "archive",
-                    "url": "https://www.freedesktop.org/software/polkit/releases/polkit-121.tar.gz",
-                    "sha256": "9dc7ae341a797c994a5a36da21963f0c5c8e3e5a1780ccc2a5f52e7be01affaa"
+                    "url": "https://www.freedesktop.org/software/polkit/releases/polkit-0.120.tar.gz",
+                    "sha256": "ee7a599a853117bf273548725719fa92fabd2f136915c7a4906cee98567aee03"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
polkit v121 switched to meson, so this requires a heavy refactoring of the polkit patch.
Until that is done, we have to go back to v120.