### PR TITLE
Fix double icon issue by adding StartupWMClass to desktop file

### DIFF
--- a/com.anydesk.Anydesk.desktop
+++ b/com.anydesk.Anydesk.desktop
@@ -8,3 +8,4 @@ Terminal=false
 TryExec=anydesk
 Type=Application
 Categories=Network;GTK;
+StartupWMClass=anydesk


### PR DESCRIPTION
Reference:
https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html