### PR TITLE
Update AnyDesk version to 7.1.4

### DIFF
--- a/com.anydesk.Anydesk.json
+++ b/com.anydesk.Anydesk.json
@@ -108,9 +108,9 @@
                 {
                     "type": "extra-data",
                     "filename": "anydesk.tar.gz",
-                    "url": "https://download.anydesk.com/linux/anydesk-7.1.3-amd64.tar.gz",
-                    "sha256": "6f559240c46515aaa11020812a83e3508c30e458f7c9f37cc31c000ae3bb451e",
-                    "size": 14932865,
+                    "url": "https://download.anydesk.com/linux/anydesk-7.1.4-amd64.tar.gz",
+                    "sha256": "ebbae6e5ba20d962dad36461d795b926cf05115ae002d09b2b0698a0deeda101",
+                    "size": 15022660,
                     "only-arches": [
                         "x86_64"
                     ],


### PR DESCRIPTION
Feb 13, 2026
- Bugfixes
- AnyDesk One chat compatibility fixes